### PR TITLE
fix: the usage of ADDITIONAL_OPTS

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -53,6 +53,7 @@ EOF
   ADDITIONAL_OPTS=""
   if [[ -n "$TAGS" ]] ; then ADDITIONAL_OPTS+="--tags=${TAGS} " ; fi
   if [[ -n "$SKIPTAGS" ]] ; then ADDITIONAL_OPTS+="--skip-tags=${SKIPTAGS} " ; fi
+  # shellcheck disable=SC2086
   ansible-playbook  --connection=local --limit localhost deploy.yml ${ADDITIONAL_OPTS}
 }
 ansible::test::playbook() {

--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -53,7 +53,7 @@ EOF
   ADDITIONAL_OPTS=""
   if [[ -n "$TAGS" ]] ; then ADDITIONAL_OPTS+="--tags=${TAGS} " ; fi
   if [[ -n "$SKIPTAGS" ]] ; then ADDITIONAL_OPTS+="--skip-tags=${SKIPTAGS} " ; fi
-  ansible-playbook  --connection=local --limit localhost deploy.yml "${ADDITIONAL_OPTS}"
+  ansible-playbook  --connection=local --limit localhost deploy.yml ${ADDITIONAL_OPTS}
 }
 ansible::test::playbook() {
   : "${TARGETS?No targets to check. Nothing to do.}"
@@ -72,7 +72,7 @@ EOF
   if [[ -n "$TAGS" ]] ; then ADDITIONAL_OPTS+="--tags=${TAGS} " ; fi
   if [[ -n "$SKIPTAGS" ]] ; then ADDITIONAL_OPTS+="--skip-tags=${SKIPTAGS} " ; fi
   # shellcheck disable=SC2086
-  ansible-playbook --connection=local "${ADDITIONAL_OPTS}" --inventory host.ini ${TARGETS}
+  ansible-playbook --connection=local ${ADDITIONAL_OPTS} --inventory host.ini ${TARGETS}
 }
 
 # make sure git is up to date


### PR DESCRIPTION
Before 1: https://github.com/timgreen/HomeConfig/actions/runs/4343576041/jobs/7585790821
Before 2: https://github.com/timgreen/HomeConfig/actions/runs/4359667804/jobs/7621703692
After: https://github.com/timgreen/HomeConfig/actions/runs/4359847515/jobs/7622097993

Basically, the quote around `${ADDITIONAL_OPTS}` will make bash to pass them as exactly one argument instead of two or zero. 

I'm not sure why ansible didn't complain in the Before 2 case, but based on the error, I could tell it didn't get the skiptag part.